### PR TITLE
upgrade distroless to debian 13

### DIFF
--- a/arlas-openjdk/Dockerfile-distroless-17
+++ b/arlas-openjdk/Dockerfile-distroless-17
@@ -5,7 +5,7 @@ RUN cd /tmp && \
     mkdir /dpkg && \
     for deb in *.deb; do dpkg --extract $deb /dpkg || exit 10; done
 
-FROM gcr.io/distroless/java17-debian12
+FROM gcr.io/distroless/java17-debian13
 WORKDIR /opt/app
 
 COPY --from=deb_extractor /dpkg /

--- a/arlas-openjdk/release.sh
+++ b/arlas-openjdk/release.sh
@@ -2,7 +2,6 @@
 set -o errexit -o pipefail
 
 VERSION=`date '+%Y%m%d%H%M%S'`
-docker pull  gcr.io/distroless/java17-debian12
 docker build --no-cache -f Dockerfile-distroless-17 --tag gisaia/arlas-openjdk-17-distroless:$VERSION .
 docker push gisaia/arlas-openjdk-17-distroless:$VERSION
 


### PR DESCRIPTION
Changes:
- Upgrade debian 12 to 13 for java distroless
- remove un-necessary docker pull