### PR TITLE
add healthcheck compiled

### DIFF
--- a/arlas-openjdk/Dockerfile-distroless-17
+++ b/arlas-openjdk/Dockerfile-distroless-17
@@ -5,9 +5,16 @@ RUN cd /tmp && \
     mkdir /dpkg && \
     for deb in *.deb; do dpkg --extract $deb /dpkg || exit 10; done
 
+FROM eclipse-temurin:17-jdk AS builder
+
+WORKDIR /opt/app
+COPY HttpHealthcheck.java .
+
+RUN javac HttpHealthcheck.java
+
 FROM gcr.io/distroless/java17-debian13
 WORKDIR /opt/app
 
 COPY --from=deb_extractor /dpkg /
-COPY HttpHealthcheck.java /opt/app/HttpHealthcheck.java
+COPY --from=builder /opt/app/HttpHealthcheck.class .
 COPY elastic-apm-agent-*.jar /opt/app/elastic-apm-agent.jar


### PR DESCRIPTION
In the newly released image, the healthcheck does not work:
**Exception in thread "main" java.lang.InternalError: Module jdk.compiler not in boot Layer**

comapred to `gcr.io/distroless/java17-debian12`,  `gcr.io/distroless/java17-debian13`, the compiler is not anymore included in the image. Therefore, it is necessary to compile the Healthcheck befor copying it in the target.

Test done:
```shell
docker build -f Dockerfile-distroless-17 . -t toto
docker run --entrypoint java toto HttpHealthcheck https://google.com ; echo $?
```
